### PR TITLE
Execute Workflow: Geoprocessing warning for Oozie URL missing scheme

### DIFF
--- a/HadoopTools.pyt
+++ b/HadoopTools.pyt
@@ -422,7 +422,7 @@ class ExecuteWorkflow(object):
 
     def __init__(self):
         self.label = "Execute Workflow"
-        self.description = "Executes Oozie workwlow"
+        self.description = "Executes Oozie workflow"
         self.canRunInBackground = False
 
     def getParameterInfo(self):
@@ -471,7 +471,9 @@ class ExecuteWorkflow(object):
         return
                 
     def updateMessages(self, parameters):
-        return
+	in_oozie_url = parameters[0].value
+	if in_oozie_url and not ':/' in in_oozie_url:
+	   parameters[0].setWarningMessage("Oozie URL does not appear to be a valid URL")
 
     def execute(self, parameters, messages):
         # Get parameters


### PR DESCRIPTION
An easy error to make with the Execute-Workflow tool, is to omit the scheme of the Oozie URL, assuming that "http" can be implicit.

If I enter a bad Oozie URL of "hadoop1/oozie", the error message is about "schema":

  Unexpected error : Invalid URL u'hadoop1/oozie/v1/admin/status': No schema supplied

However, if my bad Oozie URL is "hadoop1:11000/oozie", the error message is about "connection adapters":

  Unexpected error : No connection adapters were found for 'python1:11000/oozie/v1/admin/status'

I found the "connection adapters" error message to be confusing, the first time I was trying to use the Execute-Workflow tool and omitted the scheme from the URL.

One idea is to check such error in the Geoprocessing tool itself (rather than deferring to the requests library).  This has the advantage that the user is warned before pushing the OK button (rather than error after starting to run the tool - the user loses the entries in the dialog); and this is what is implemented in this pull request (it also fixes one typo).

```
def updateMessages(self, parameters):
in_oozie_url = parameters[0].value
if in_oozie_url and not ':/' in in_oozie_url:
   parameters[0].setWarningMessage("Oozie URL does not appear to be a valid URL")
```

An alternate approach would be to patch the requests library such that the error from the requests library talks about "schema"/"scheme" in both cases.  (Speculation: it differs due to the ':' character even though it does not contain ":/".)

Yet another alternate approach would be to prepend an implicit "http://" when scheme is omitted.
